### PR TITLE
Remove Player logic that edits history.

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -37,18 +37,6 @@ Player.prototype.new = function() {
   views[entry.id] += 1;
   this.store.set('views', views);
   this._show(entry, true);
-  if (history.state) {
-    history.pushState(entry.id);
-  } else {
-    history.replaceState(entry.id);
-  }
-};
-
-/**
- * Show the next entry.
- */
-Player.prototype.next = function() {
-  history.forward();
 };
 
 /**


### PR DESCRIPTION
When the `Player.prototype.new` function pushes to history, an unfortunate situation occurs...

- I open a new tab
- I browse in that tab for some time.
- I try to go back to some part of that tab's history, a page that I had open early in that tab's lifetime.
- Oops, I went too far, ended up hitting back all the way up to the 'new tab' screen, which is now another one of PlanetLab's beautiful images.
- I'd like to just hit forward and keep browsing for the page I'm looking for...but suddenly the entire history for that tab is gone.
(This has happened to me more than 20 times by now).

This PR is not without cost: the edits to the history was in service to of a feature where, if you click the lower righthand globe, and get a new image, you were previously able to hit the browser back button to view the previous images. If this feature is a must-have, it could probably be coded in such a way that it doesn't destroy the user's history when they have navigated off of the new tab screen. I'd be open for suggestions to modifications of this PR if that's a feature that needs to be kept.

Fixes #33 