### PR TITLE
Local storage for history instead of browser history

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "postcss-cli": "^2.5.1",
     "queue-async": "^1.2.1",
     "semver": "^5.1.0",
-    "sinon": "^1.17.3",
     "topojson": "^1.6.18",
     "uglify-js": "^2.6.2",
     "watchy": "0.6.6"

--- a/src/main.js
+++ b/src/main.js
@@ -50,5 +50,19 @@ function ready(err, world, gallery) {
     player.new();
   });
 
+  d3.select('body').on('keydown', function() {
+    switch (d3.event.keyCode) {
+      case 39:
+        player.next();
+        break;
+      case 37:
+        player.previous();
+        document.body.focus();
+        break;
+      default:
+        // pass
+    }
+  });
+
   player.new();
 }

--- a/src/player.test.js
+++ b/src/player.test.js
@@ -8,17 +8,17 @@ lab.experiment('Player', function() {
 
   lab.beforeEach(util.addGlobals);
 
-  lab.afterEach(util.removeGlobals);
+  lab.afterEach(util.restoreGlobals);
 
   lab.test('constructor', function(done) {
     var player = new Player();
     expect(player).to.be.an.instanceof(Player);
 
-    expect(global.addEventListener.calledOnce).to.be.true();
-    var call = global.addEventListener.getCall(0);
-    expect(call.args[0]).to.equal('popstate');
-
     expect(player.store.get('views')).to.deep.equal({});
+    expect(player.store.get('history')).to.deep.equal({
+      current: -1,
+      entries: []
+    });
     done();
   });
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -32,7 +32,7 @@ Scene.prototype.show = function(data, callback) {
   // TODO: rework scene markup
   var title = data.title + ' - ' + moment(data.acquisition_date).calendar();
   d3.select('#image-title')
-      .html('<a href="' + data.link + '">' + title + '</a>');
+      .html('<a tabindex="1" href="' + data.link + '">' + title + '</a>');
 };
 
 /**

--- a/src/store.test.js
+++ b/src/store.test.js
@@ -8,7 +8,7 @@ lab.experiment('Store', function() {
 
   lab.beforeEach(util.addGlobals);
 
-  lab.afterEach(util.removeGlobals);
+  lab.afterEach(util.restoreGlobals);
 
   lab.test('constructor', function(done) {
     var store = new Store();

--- a/src/util.js
+++ b/src/util.js
@@ -1,14 +1,18 @@
 var MockStorage = require('dom-storage');
-var sinon = require('sinon');
+
+var localStorage;
 
 exports.addGlobals = function(done) {
+  localStorage = global.localStorage;
   global.localStorage = new MockStorage(null, {strict: true});
-  global.addEventListener = sinon.spy();
   done();
 };
 
-exports.removeGlobals = function(done) {
-  delete global.localStorage;
-  delete global.addEventListener;
+exports.restoreGlobals = function(done) {
+  if (localStorage) {
+    global.localStorage = localStorage;
+  } else {
+    delete global.localStorage;
+  }
   done();
 };


### PR DESCRIPTION
This makes it so the extension no longer messes with the browser history.  Instead, a "global" history is maintained in local storage.  When the document has focus, `→` loads the next image (or a new one if at the head) and `←` loads the previous image.  Clicking on the globe advances to the head and loads a new image.

This works across sessions.  So if you open a new tab, see a cool image, but load a new page before really enjoying it, you can open a new tab and navigate back to the previous image with `←`.

One thing to keep in mind is that the location bar has focus when the new tab page first loads.  So you have to click the document or tab to it (with two tabs) for the key handling to work.