### PR TITLE
Remove date check on list of available images

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,11 +37,9 @@ function ready(err, world, gallery) {
 
   for (var i = 0, ii = gallery.length; i < ii; ++i) {
     entry = gallery[i];
-    if (new Date(entry.publish_date) > old) {
-      // assume link is stable identifier
-      entry.id = entry.link;
-      entries[entry.id] = entry;
-    }
+    // assume link is stable identifier
+    entry.id = entry.link;
+    entries[entry.id] = entry;
   }
 
   var player = new Player(entries, scene, globe);


### PR DESCRIPTION
New images are not being added to Planet's gallery, so the number of scenes that are less than a year old has dwindled to 4. I'm a little tired of them, so I removed the date check to shuffle through the entire gallery.

~One inadvertent consequence is the CDN seems slow to deliver the images (around 1 min/image, but this is from a very slow 0.1 Mbps coffee shop).~ (Better wifi resolved issue)
Additionally, the `make start` failed on my setup. I'm unsure if this is a local issue, or the make process needs to be updated. Either way, running `make dev dist` functioned properly. `make test` does fail though, but isn't a result of this change.