### PR TITLE
Firefox compatibility

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,19 +9,6 @@
 <body>
   <div id="scene"></div>
 
-  <ul class="nav">
-    <li class="nav-item">
-      <a data-hook="chrome-link" title="Apps Tab" href="chrome://apps/">
-        <i class="mdi-navigation-apps"></i>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a data-hook="chrome-link" title="Default New Tab" href="chrome-search://local-ntp/local-ntp.html">
-        <i class="mdi-action-open-in-new"></i>
-      </a>
-    </li>
-  </ul>
-
   <div class="attribution">
     <a href="https://www.planet.com/"><span class="watermark"></span></a>
     <span class="attribution-copy">

--- a/src/main.js
+++ b/src/main.js
@@ -5,12 +5,6 @@ var Globe = require('./globe');
 var Player = require('./player');
 var Scene = require('./scene');
 
-// navigation to other chrome pages
-d3.selectAll('a[data-hook="chrome-link"]').on('click', function() {
-  d3.event.preventDefault();
-  chrome.tabs.update({url: d3.event.currentTarget.href});
-});
-
 // trigger data loading
 queue()
   .defer(d3.json, 'assets/data/world-110m.json')

--- a/src/main.less
+++ b/src/main.less
@@ -16,14 +16,6 @@
   -webkit-font-smoothing: antialiased;
 }
 
-.mdi-navigation-apps:before {
-  content: "\e892"
-}
-
-.mdi-action-open-in-new:before {
-  content: "\e648"
-}
-
 body {
   font-family: sans-serif;
   font-size: 18px;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,5 +11,5 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "incognito": "split"
+  "incognito": "not_allowed"
 }


### PR DESCRIPTION
**note:** This is a WIP branch because I just wanted to show it was possible but there could be more work to retain a single codebase with multi-target builds that I did not investigate.

So I was a huge fan of this extension on chrome, but I've switched to using firefox for the most part a few years ago and I wanted to see how difficult it would be to make this extension compatible with ff. Turns out it wasn't that difficult to get something that seems to work.

The critical fix was changing the `incognito` setting in the manifest, although `"split"` [should work?](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) changing it to spanning or not_allowed worked for me. I used firefox dev edition 76.0b8, and I hope it would work on 75.0.

I also removed the nav div as that seemed to be chrome specific and unneeded for FF but maybe equivalent links are available. 

So it seems it should be easy to support both browsers. I've allowed the maintainers to edit so maybe this pr could be expanded upon. 

compatibility report from https://www.extensiontest.com: 
[report.txt](https://github.com/planetlabs/planet-view-chrome-ext/files/4535994/report.txt)
